### PR TITLE
AHCI cleanup

### DIFF
--- a/src/drivers/storage/ahci.asm
+++ b/src/drivers/storage/ahci.asm
@@ -118,16 +118,15 @@ ahci_init_not_found:
 
 
 ; -----------------------------------------------------------------------------
-; ahci_read -- Read data from a SATA hard drive
-; IN:	RAX = starting sector # to read (48-bit LBA address)
-;	RCX = number of sectors to read (up to 8192 = 4MiB)
+; ahci_io -- Perform an I/O operation on an AHCI device
+; IN:	RAX = starting sector # (48-bit LBA address)
+;	RBX = I/O Opcode
+;	RCX = number of sectors
 ;	RDX = disk #
-;	RDI = memory location to store sectors
-; OUT:	RAX = RAX + number of sectors that were read
-;	RCX = number of sectors that were read (0 on error)
-;	RDI = RDI + (number of sectors read * 512)
+;	RDI = memory location
+; OUT:	Nothing
 ;	All other registers preserved
-ahci_read:
+ahci_io:
 	push rdx
 	push rbx
 	push rdi
@@ -138,11 +137,11 @@ ahci_read:
 	shl rax, 3			; Convert to 512B starting sector
 	shl rcx, 3			; Convert 4K sectors to 512B sectors
 
-	bt dword [ahci_PA], edx		; Is the requested disk marked as active?
-	jnc achi_read_error		; If not, bail out
+	bt dword [ahci_PA], edx		; Is the requested device marked as active?
+	jnc achi_io_error		; If not, bail out
 	
 	cmp rcx, 8192			; Are we trying to read more that 4MiB?
-	jge achi_read_error		; If so, bail out
+	jge achi_io_error		; If so, bail out
 
 	push rcx			; Save the sector count
 	push rdi			; Save the destination memory address
@@ -162,6 +161,10 @@ ahci_read:
 	add rdi, rdx
 	shr rdx, 10
 	mov eax, 0x00010005		; 1 PRDTL Entry, Command FIS Length = 20 bytes
+	cmp ebx, 0x35
+	jne ahci_io_skip_writebit
+	bts ebx, 6			; Set the write flag (bit 6)
+ahci_io_skip_writebit:
 	stosd				; DW 0 - Description Information
 	xor eax, eax
 	stosd				; DW 1 - Command Status
@@ -175,7 +178,9 @@ ahci_read:
 
 	; Build the Command Table
 	mov rdi, ahci_CMD		; Build a command table for Port 0
-	mov eax, 0x00258027		; 25 READ DMA EXT, bit 15 set, FIS 27 H2D
+	mov eax, ebx
+	shl eax, 16			; Shift command to bits 31:16
+	add eax, 0x8027			; bit 15 set, FIS 27 H2D
 	stosd				; feature 7:0, command, c, FIS
 	pop rax				; Restore the start sector number
 	shl rax, 36
@@ -214,10 +219,10 @@ ahci_read:
 	bts eax, 0			; Start (ST)
 	mov [rsi+AHCI_PxCMD], eax	; Offset to port 0 Command and Status
 
-ahci_read_poll:
+ahci_io_poll:
 	mov eax, [rsi+AHCI_PxCI]
 	test eax, eax
-	jnz ahci_read_poll
+	jnz ahci_io_poll
 
 	mov eax, [rsi+AHCI_PxCMD]	; Offset to port 0
 	btr eax, 4			; FIS Receive Enable (FRE)
@@ -236,140 +241,9 @@ ahci_read_poll:
 	pop rdx
 	ret
 
-achi_read_error:
+achi_io_error:
 	pop rax				; rax = start
 	pop rcx				; rcx = number of sectors read
-	pop rsi
-	pop rdi
-	pop rbx
-	pop rdx
-	xor ecx, ecx
-	ret
-; -----------------------------------------------------------------------------
-
-
-; -----------------------------------------------------------------------------
-; ahci_write -- Write data to a SATA hard drive
-; IN:	RAX = starting sector # to write (48-bit LBA Address)
-;	RCX = number of sectors to write (up to 8192 = 4MiB)
-;	RDX = disk #
-;	RSI = memory location of sectors
-; OUT:	RAX = RAX + number of sectors that were written
-;	RCX = number of sectors that were written (0 on error)
-;	RSI = RSI + (number of sectors written * 512)
-;	All other registers preserved
-ahci_write:
-	push rdx
-	push rbx
-	push rdi
-	push rsi
-	push rcx
-	push rax
-
-	shl rax, 3			; Convert to 512B starting sector
-	shl rcx, 3			; Convert 4K sectors to 512B sectors
-
-	bt dword [ahci_PA], edx		; Is the requested disk marked as active?
-	jnc achi_write_error		; If not, bail out
-	
-	cmp rcx, 8192			; Are we trying to write more that 4MiB?
-	jge achi_write_error		; If so, bail out
-
-	push rcx			; Save the sector count
-	push rsi			; Save the source memory address
-	push rax			; Save the block number
-	push rax
-
-	mov rsi, [ahci_base]
-	push rdx
-	shl rdx, 7			; Quick multiply by 0x80
-	add rdx, 0x100			; Offset to port 0
-	add rsi, rdx
-	pop rdx
-
-	; Build the Command List Header
-	mov rdi, ahci_CLB		; Command List (1K with 32 entries, 32 bytes each)
-	shl rdx, 10
-	add rdi, rdx
-	shr rdx, 10
-	mov eax, 0x00010045		; 1 PRDTL Entry, write flag (bit 6), Command FIS Length = 20 bytes
-	stosd				; DW 0 - Description Information
-	xor eax, eax
-	stosd				; DW 1 - Command Status
-	mov rax, ahci_CMD
-	stosd				; DW 2 - Command Table Base Address
-	shr rax, 32			; 63..32 bits of address
-	stosd				; DW 3 - Command Table Base Address Upper
-	xor eax, eax
-	stosq				; DW 4 - 7 are reserved
-	stosq
-
-	; Build the Command Table
-	mov rdi, ahci_CMD		; Build a command table for Port 0
-	mov eax, 0x00358027		; 35 WRITE DMA EXT, bit 15 set, FIS 27 H2D
-	stosd				; feature 7:0, command, c, FIS
-	pop rax				; Restore the start sector number
-	shl rax, 36
-	shr rax, 36			; Upper 36 bits cleared
-	bts rax, 30			; bit 30 set for LBA
-	stosd				; device, LBA 23:16, LBA 15:8, LBA 7:0
-	pop rax				; Restore the start sector number
-	shr rax, 24
-	stosd				; feature 15:8, LBA 47:40, LBA 39:32, LBA 31:24
-	mov rax, rcx			; Read the number of sectors given in rcx
-	stosd				; control, ICC, count 15:8, count 7:0
-	xor eax, eax
-	stosd				; reserved
-
-	; PRDT setup
-	mov rdi, ahci_CMD + 0x80
-	pop rax				; Restore the source memory address
-	stosd				; Data Base Address
-	shr rax, 32
-	stosd				; Data Base Address Upper
-	xor eax, eax
-	stosd				; Reserved
-	pop rax				; Restore the sector count
-	shl rax, 9			; multiply by 512 for bytes
-	dec rax				; subtract 1 (4.2.3.3, DBC is number of bytes - 1)
-	stosd				; Description Information (DBC is 21:00)
-
-	xor eax, eax
-	mov [rsi+AHCI_PxIS], eax	; Port x Interrupt Status
-
-	mov eax, 0x00000001		; Execute Command Slot 0
-	mov [rsi+AHCI_PxCI], eax
-
-	xor eax, eax
-	bts eax, 4			; FIS Receive Enable (FRE)
-	bts eax, 0			; Start (ST)
-	mov [rsi+AHCI_PxCMD], eax	; Offset to port 0 Command and Status
-
-ahci_write_poll:
-	mov eax, [rsi+AHCI_PxCI]
-	test eax, eax
-	jnz ahci_write_poll
-
-	mov eax, [rsi+AHCI_PxCMD]	; Offset to port 0
-	btr eax, 4			; FIS Receive Enable (FRE)
-	btr eax, 0			; Start (ST)
-	mov [rsi+AHCI_PxCMD], eax
-
-	pop rax				; rax = start
-	pop rcx				; rcx = number of sectors read
-	add rax, rcx			; rax = start + number of sectors written
-	pop rsi
-	pop rdi
-	mov rbx, rcx			; rdi = dest addr + number of bytes written
-	shl rbx, 9
-	add rdi, rbx
-	pop rbx
-	pop rdx
-	ret
-
-achi_write_error:
-	pop rax
-	pop rcx
 	pop rsi
 	pop rdi
 	pop rbx
@@ -520,6 +394,10 @@ AHCI_PxFBS		equ 0x0040 ; Port x FIS-based Switching Control
 AHCI_PxDEVSLP		equ 0x0044 ; Port x Device Sleep
 ; 0x0048 - 0x006F	Reserved
 ; 0x0070 - 0x007F	Port x Vendor Specific
+
+; Opcodes for AHCI Commands
+AHCI_Write		equ 0x35
+AHCI_Read		equ 0x25
 
 
 ; =============================================================================

--- a/src/syscalls/disk.asm
+++ b/src/syscalls/disk.asm
@@ -29,7 +29,8 @@ b_disk_read:
 	jge b_disk_read_nvme
 
 b_disk_read_ahci:
-	call ahci_read
+	mov ebx, AHCI_Read
+	call ahci_io
 
 b_disk_read_done:
 	pop rax
@@ -40,7 +41,7 @@ b_disk_read_done:
 
 b_disk_read_nvme:
 	sub rdx, 99			; To BareMetal the first NVMe drive is 100. Internally it is 1
-	mov rbx, NVMe_Read
+	mov ebx, NVMe_Read
 	call nvme_io
 	add rdx, 99
 	jmp b_disk_read_done
@@ -75,7 +76,8 @@ b_disk_write:
 	jge b_disk_write_nvme
 
 b_disk_write_ahci:
-	call ahci_write
+	mov ebx, AHCI_Write
+	call ahci_io
 
 b_disk_write_done:
 	pop rax
@@ -86,7 +88,7 @@ b_disk_write_done:
 
 b_disk_write_nvme:
 	sub rdx, 99			; To BareMetal the first NVMe drive is 100. Internally it is 1
-	mov rbx, NVMe_Write
+	mov ebx, NVMe_Write
 	call nvme_io
 	add rdx, 99
 	jmp b_disk_write_done

--- a/src/sysvar.asm
+++ b/src/sysvar.asm
@@ -114,6 +114,9 @@ os_NVMeTER:		equ os_SystemVariables + 788
 os_NVMeLBA:		equ os_SystemVariables + 789
 os_NVMe_atail:		equ os_SystemVariables + 790
 os_NVMe_iotail:		equ os_SystemVariables + 791
+os_AHCIMJR:		equ os_SystemVariables + 792
+os_AHCIMNR:		equ os_SystemVariables + 792
+os_AHCIIRQ:		equ os_SystemVariables + 793
 
 
 ; Misc


### PR DESCRIPTION
- Consolidate read/write into one I/O function like the NVMe driver.
- Save the version and IRQ
- Adjust b_disk* functions for new AHCI call