### PR TITLE
Higherhalf fix

### DIFF
--- a/api/libBareMetal.asm
+++ b/api/libBareMetal.asm
@@ -9,8 +9,8 @@
 b_input			equ 0x0000000000100010	; Scans keyboard for input. OUT: AL = 0 if no key pressed, otherwise ASCII code
 b_output		equ 0x0000000000100018	; Displays a number of characters. IN: RSI = message location, RCX = number of characters
 
-b_net_tx		equ 0x0000000000100020	; Transmit a packet via a network interface. IN: RSI = Memory location where data is stored, RDI = Pointer to 48 bit destination address, BX = Type of packet (If set to 0 then the EtherType will be set to the length of data), CX = Length of data
-b_net_rx		equ 0x0000000000100028	; Polls the network interface for received data. IN: RDI = Memory location where packet will be stored. OUT: RCX = Length of packet
+b_net_tx		equ 0x0000000000100020	; Transmit a packet via a network interface. IN: RSI = Memory location where packet is stored, RCX = Length of packet
+b_net_rx		equ 0x0000000000100028	; Polls the network interface for received packet. IN: RDI = Memory location where packet will be stored. OUT: RCX = Length of packet
 
 b_storage_read		equ 0x0000000000100030	; Read data from a drive. IN: RAX = Starting sector, RCX = Number of sectors to read, RDX = Drive, RDI = Memory location to store data
 b_storage_write		equ 0x0000000000100038	; Write data to a drive. IN: RAX = Starting sector, RCX = Number of sectors to write, RDX = Drive, RSI = Memory location of data to store

--- a/src/drivers/net/i8254x.asm
+++ b/src/drivers/net/i8254x.asm
@@ -235,8 +235,6 @@ net_i8254x_poll:
 	mov rax, os_PacketBuffers		; Packet will go here
 	add rax, 2				; Room for packet length
 	stosd
-	mov rax, [os_PacketBuffers]
-	call os_debug_dump_rax
 
 	pop rax
 	pop rsi

--- a/src/drivers/net/i8254x.asm
+++ b/src/drivers/net/i8254x.asm
@@ -15,7 +15,7 @@ net_i8254x_init:
 	push rcx
 	push rax
 
-	; Read BAR4, If BAR4 is all 0'z then we are using 32-bit addresses
+	; Read BAR4, If BAR4 is all zeros then we are using 32-bit addresses
 
 	; Grab the Base I/O Address of the device
 	mov dl, 0x04				; BAR0

--- a/src/drivers/net/i8254x.asm
+++ b/src/drivers/net/i8254x.asm
@@ -134,7 +134,7 @@ net_i8254x_reset:
 	mov [rsi+I8254X_REG_RDBAL], eax		; Receive Descriptor Base Address Low
 	shr rax, 32
 	mov [rsi+I8254X_REG_RDBAH], eax		; Receive Descriptor Base Address High
-	mov eax, (32 * 8)			; Multiples of 8, each desciptor is 16 bytes
+	mov eax, (32 * 8)			; Multiples of 8, each descriptor is 16 bytes
 	mov [rsi+I8254X_REG_RDLEN], eax		; Receive Descriptor Length
 	xor eax, eax
 	mov [rsi+I8254X_REG_RDH], eax		; Receive Descriptor Head
@@ -154,7 +154,7 @@ net_i8254x_reset:
 	mov [rsi+I8254X_REG_TDBAL], eax		; Transmit Descriptor Base Address Low
 	shr rax, 32
 	mov [rsi+I8254X_REG_TDBAH], eax		; Transmit Descriptor Base Address High
-	mov eax, (32 * 8)			; Multiples of 8, each desciptor is 16 bytes
+	mov eax, (32 * 8)			; Multiples of 8, each descriptor is 16 bytes
 	mov [rsi+I8254X_REG_TDLEN], eax		; Transmit Descriptor Length
 	xor eax, eax
 	mov [rsi+I8254X_REG_TDH], eax		; Transmit Descriptor Head
@@ -222,16 +222,21 @@ net_i8254x_poll:
 	mov rdi, os_PacketBuffers
 	mov [rdi], word cx
 
+	; Reset the descriptor head and tail
+	; TODO - Fix this to actually make use of all the available descriptors
 	mov rsi, [os_NetIOBaseMem]
 	xor eax, eax
 	mov [rsi+I8254X_REG_RDH], eax		; Receive Descriptor Head
 	inc eax
 	mov [rsi+I8254X_REG_RDT], eax		; Receive Descriptor Tail
 
+	; Reset the Receive Descriptor for a new packet
 	mov rdi, os_rx_desc
 	mov rax, os_PacketBuffers		; Packet will go here
 	add rax, 2				; Room for packet length
 	stosd
+	mov rax, [os_PacketBuffers]
+	call os_debug_dump_rax
 
 	pop rax
 	pop rsi

--- a/src/syscalls/net.asm
+++ b/src/syscalls/net.asm
@@ -104,7 +104,6 @@ b_net_rx:
 	pop rcx
 
 b_net_rx_fail:
-
 	pop rax
 	pop rsi
 	pop rdi

--- a/src/syscalls/net.asm
+++ b/src/syscalls/net.asm
@@ -58,6 +58,11 @@ b_net_tx_maxcheck:
 	mov rax, os_NetLock		; Lock the net so only one send can happen at a time
 	call b_smp_lock
 
+	; Calculate where in physical memory the data should be read from
+	xchg rax, rsi
+	call os_virt_to_phys
+	xchg rax, rsi
+
 	inc qword [os_net_TXPackets]
 	add qword [os_net_TXBytes], rcx
 	call qword [os_net_transmit]	; Call the driver

--- a/src/syscalls/storage.asm
+++ b/src/syscalls/storage.asm
@@ -23,8 +23,10 @@ b_storage_read:
 	cmp rcx, 0
 	je b_storage_read_fail		; Bail out if instructed to read nothing
 
-	; Calculate where in physical memory the data should be read to
+	; Calculate where in physical memory the data should be written to
+	xchg rax, rdi
 	call os_virt_to_phys
+	xchg rax, rdi
 
 	; TODO rework how drive numbering works
 	cmp byte [os_NVMeEnabled], 1
@@ -77,6 +79,11 @@ b_storage_write:
 
 	cmp rcx, 0
 	je b_storage_write_fail		; Bail out if instructed to write nothing
+
+	; Calculate where in physical memory the data should be read from
+	xchg rax, rsi
+	call os_virt_to_phys
+	xchg rax, rsi
 
 	; TODO rework how drive numbering works
 	cmp byte [os_NVMeEnabled], 1

--- a/src/syscalls/storage.asm
+++ b/src/syscalls/storage.asm
@@ -23,6 +23,9 @@ b_storage_read:
 	cmp rcx, 0
 	je b_storage_read_fail		; Bail out if instructed to read nothing
 
+	; Calculate where in physical memory the data should be read to
+	call os_virt_to_phys
+
 	; TODO rework how drive numbering works
 	cmp byte [os_NVMeEnabled], 1
 	je b_storage_read_nvme

--- a/src/syscalls/system.asm
+++ b/src/syscalls/system.asm
@@ -141,5 +141,31 @@ reboot:
 ; -----------------------------------------------------------------------------
 
 
+; -----------------------------------------------------------------------------
+; os_virt_to_phys -- Function to convert a virtual address to a physical address
+; IN:	RAX = Virtual Memory Address
+; OUT:	RAX = Physical Memory Address
+;	All other registers preserved
+; NOTE: BareMetal uses two ranges of memory. One physical 1-to-1 map and one virtual
+;	range for free memory
+os_virt_to_phys:
+	push r15
+	mov r15, 0xFFFF800000000000	; Starting address of the higher half
+	cmp rdi, r15			; Check if RDI is in the upper canonical range
+	jg os_virt_to_phys_done		; If not, it is already a physical address - bail out
+
+	sub rdi, r15
+	mov r15, sys_pdh		; Location of virtual memory PDs
+	shr rdi, 18			; Convert 2MB page to entry
+	mov rdi, [r15]			; Load the entry into RDI
+	shr rdi, 8			; Clear the low 8 bits
+	shl rdi, 8
+
+os_virt_to_phys_done:
+	pop r15
+	ret
+; -----------------------------------------------------------------------------
+
+
 ; =============================================================================
 ; EOF


### PR DESCRIPTION
- Added a function called os_virt_to_phys that would convert a virtual address to its physical address. This is needed for PCI device access with storage and networking.
- Misc spelling fixes and comments