### PR TITLE
HPET / delay simplification

### DIFF
--- a/src/drivers/hpet.asm
+++ b/src/drivers/hpet.asm
@@ -18,24 +18,6 @@ os_hpet_init:
 	mov rax, [os_HPET_Address]
 	jz os_hpet_init_error
 
-	; Calculate which IRQ to use on the I/O APIC
-	mov ecx, HPET_TIMER_0_CONF
-	call os_hpet_read		; Supported IRQ lines to the I/O APIC are in bits 55:32 (translated to 23:0)
-	shr rax, 32			; Shift upper bits to lower
-	bsr eax, eax			; Find the highest set bit in EAX, store bit number in EAX
-	mov [os_HPET_IRQ], al		; Save IRQ number
-	mov edi, eax			; Copy IRQ number for setting the IDT
-	mov ecx, eax			; Copy IRQ number for unmasking the I/O APIC
-
-	; Create a gate in the IDT
-	add edi, 0x20			; Convert to interrupt gate number (Exceptions use 0-31)
-	mov rax, hpet
-	call create_gate
-
-	; Allow HPET interrupts via the I/O APIC. ECX should still contain the IRQ number HPET IRQ
-	mov eax, edi			; HPET Interrupt Vector
-	call os_ioapic_mask_clear
-
 	; Set flag that HPET was enabled
 	or qword [os_SysConfEn], 1 << 4
 


### PR DESCRIPTION
- Remove `os_delay` as HPET ticks aren’t that useful
- Remove interrupts from `b_delay`
- Remove interrupt setup in `os_hpet_init`