### PR TITLE
`virtio-net` driver rewrite

### DIFF
--- a/src/drivers/net/virtio-net.asm
+++ b/src/drivers/net/virtio-net.asm
@@ -564,7 +564,10 @@ net_virtio_poll:
 	mov rdi, os_PacketBuffers
 	add word [netrxdescindex], 1
 	add word [netrxavailindex], 1
-	add word [lastrx], 1
+	mov ax, [lastrx]
+	add al, 1			; AL will wrap back to zero if needed
+	mov [lastrx], ax
+	mov [r8+0x2002], ax		; Store the new index
 
 net_virtio_poll_nodata:
 	pop rax


### PR DESCRIPTION
This pull request significantly refactors the VirtIO network driver to support multiple network interfaces and improve descriptor management. The changes replace the use of global/static variables with per-interface data structures, update how descriptor tables and rings are managed, and streamline packet transmit/receive logic for better correctness and maintainability.

Key improvements and refactoring:

**Per-Interface Data Management:**
* Replaced global variables (such as `os_net_mem`, `netrxdescindex`, `nettxdescindex`, etc.) with per-interface fields accessed via offsets from an interface structure (using `r8`/`rdx` and offsets like `nt_rx_desc`, `nt_tx_desc`, etc.), enabling support for multiple network interfaces and eliminating shared state. [[1]](diffhunk://#diff-6f3887d52904e1ebf48c74ad18b429fc87ce5684dd2c4baa8b6fd917458830fbR238) [[2]](diffhunk://#diff-6f3887d52904e1ebf48c74ad18b429fc87ce5684dd2c4baa8b6fd917458830fbL307-R308) [[3]](diffhunk://#diff-6f3887d52904e1ebf48c74ad18b429fc87ce5684dd2c4baa8b6fd917458830fbL333-R334) [[4]](diffhunk://#diff-6f3887d52904e1ebf48c74ad18b429fc87ce5684dd2c4baa8b6fd917458830fbL353-R406) [[5]](diffhunk://#diff-6f3887d52904e1ebf48c74ad18b429fc87ce5684dd2c4baa8b6fd917458830fbR456-R491) [[6]](diffhunk://#diff-6f3887d52904e1ebf48c74ad18b429fc87ce5684dd2c4baa8b6fd917458830fbL453-R517) [[7]](diffhunk://#diff-6f3887d52904e1ebf48c74ad18b429fc87ce5684dd2c4baa8b6fd917458830fbR528-R587) [[8]](diffhunk://#diff-6f3887d52904e1ebf48c74ad18b429fc87ce5684dd2c4baa8b6fd917458830fbL541-L544)

**Descriptor Table and Ring Handling:**
* Updated initialization routines to use per-interface descriptor table addresses, and improved how RX/TX descriptor rings are populated and managed. This includes new logic for resetting, populating, and wrapping descriptor indices and handling the available and used rings per interface. [[1]](diffhunk://#diff-6f3887d52904e1ebf48c74ad18b429fc87ce5684dd2c4baa8b6fd917458830fbL353-R406) [[2]](diffhunk://#diff-6f3887d52904e1ebf48c74ad18b429fc87ce5684dd2c4baa8b6fd917458830fbL307-R308) [[3]](diffhunk://#diff-6f3887d52904e1ebf48c74ad18b429fc87ce5684dd2c4baa8b6fd917458830fbL333-R334) [[4]](diffhunk://#diff-6f3887d52904e1ebf48c74ad18b429fc87ce5684dd2c4baa8b6fd917458830fbR427-R444) [[5]](diffhunk://#diff-6f3887d52904e1ebf48c74ad18b429fc87ce5684dd2c4baa8b6fd917458830fbR456-R491) [[6]](diffhunk://#diff-6f3887d52904e1ebf48c74ad18b429fc87ce5684dd2c4baa8b6fd917458830fbL453-R517) [[7]](diffhunk://#diff-6f3887d52904e1ebf48c74ad18b429fc87ce5684dd2c4baa8b6fd917458830fbR528-R587)

**Transmit and Receive Logic:**
* Refactored `net_virtio_transmit` and `net_virtio_poll` to use per-interface descriptor tables and indices, improved ring index management, and ensured correct address calculations for packet data. Also, improved handling of the used/available rings for packet transmission and reception, including proper wrap-around of indices. [[1]](diffhunk://#diff-6f3887d52904e1ebf48c74ad18b429fc87ce5684dd2c4baa8b6fd917458830fbR456-R491) [[2]](diffhunk://#diff-6f3887d52904e1ebf48c74ad18b429fc87ce5684dd2c4baa8b6fd917458830fbL453-R517) [[3]](diffhunk://#diff-6f3887d52904e1ebf48c74ad18b429fc87ce5684dd2c4baa8b6fd917458830fbR528-R587)

**Cleanup and Removal of Global State:**
* Removed global/static variables related to descriptor and ring indices (`netrxdescindex`, `netrxavailindex`, `nettxdescindex`, `nettxavailindex`), as these are now managed per interface.

**General Code Organization and Comments:**
* Improved comments and code organization, clarified TODOs, and commented out obsolete or now-redundant code sections related to old assumptions (e.g., fixed 256 entries).

These changes make the VirtIO network driver more robust, modular, and ready for environments with multiple network devices.