### PR TITLE
Update API for `b_net_rx` to update passed pointer value

### DIFF
--- a/api/libBareMetal.c
+++ b/api/libBareMetal.c
@@ -28,9 +28,9 @@ void b_net_tx(void *mem, u64 len, u64 iid) {
 	asm volatile ("call *0x00100020" : : "S"(mem), "c"(len), "d"(iid));
 }
 
-u64 b_net_rx(void *mem, u64 iid) {
+u64 b_net_rx(void **mem, u64 iid) {
 	u64 tlong;
-	asm volatile ("call *0x00100028" : "=D"(mem), "=c"(tlong) : "d"(iid));
+	asm volatile ("call *0x00100028" : "=D"(*mem), "=c"(tlong) : "d"(iid));
 	return tlong;
 }
 

--- a/api/libBareMetal.h
+++ b/api/libBareMetal.h
@@ -22,7 +22,7 @@ void b_output(const char *str, u64 nbr);
 
 // Network
 void b_net_tx(void *mem, u64 len, u64 iid);
-u64 b_net_rx(void *mem, u64 iid);
+u64 b_net_rx(void **mem, u64 iid);
 
 // Non-volatile Storage
 u64 b_nvs_read(void *mem, u64 start, u64 num, u64 drivenum);


### PR DESCRIPTION
This pull request updates the interface and implementation of the `b_net_rx` function in the network API to improve how memory is handled for network receive operations. The main change is that `b_net_rx` now takes a pointer to a pointer for its memory buffer, which allows the function to modify the caller's pointer directly.

**Network API changes:**

* Changed the signature of `b_net_rx` in both `libBareMetal.h` and `libBareMetal.c` to accept a `void **mem` parameter instead of `void *mem`, enabling the function to update the memory pointer provided by the caller. [[1]](diffhunk://#diff-d49eb285a44c9702d18e9c60bd2e7146c6e6dea48a53ed1e87c050f191aea202L25-R25) [[2]](diffhunk://#diff-54f38a879b066474139d0f720b118de3ac2aea761e2805e6f97e44d980004bd4L31-R33)
* Updated the inline assembly in `b_net_rx` to correctly dereference and assign to the memory pointer passed in by the caller, ensuring proper handling of the received buffer address.