### PR TITLE
Add flag for NASM v3+

### DIFF
--- a/src/kernel.asm
+++ b/src/kernel.asm
@@ -8,6 +8,7 @@
 
 BITS 64					; Specify 64-bit
 ORG 0x0000000000100000			; The kernel needs to be loaded at this address
+DEFAULT ABS
 
 %DEFINE BAREMETAL_VER 'v1.0.0 (January 21, 2020)', 13, 'Copyright (C) 2008-2025 Return Infinity', 13, 0
 %DEFINE BAREMETAL_API_VER 1


### PR DESCRIPTION
This pull request introduces a small change to the assembly file `src/kernel.asm` by adding the `DEFAULT ABS` directive. This directive sets the default addressing mode to absolute, which can help clarify the intent of memory references in the code.