### PR TITLE
Add initial x2APIC support

### DIFF
--- a/src/drivers/apic.asm
+++ b/src/drivers/apic.asm
@@ -20,27 +20,59 @@ os_apic_init:
 
 
 ; -----------------------------------------------------------------------------
-; os_apic_read -- Read from a register in the APIC
+; os_apic_read -- Read from a register in the APIC/x2APIC
 ;  IN:	ECX = Register to read
-; OUT:	EAX = Register value
+; OUT:	RAX = Register value
 ;	All other registers preserved
 os_apic_read:
+	cmp byte [os_x2APIC], 1
+	je os_apic_read_x2
+
+os_apic_read_x:
 	mov rax, [os_LocalAPICAddress]
 	mov eax, [rax + rcx]
+	ret
+
+os_apic_read_x2:
+	push rdx
+	push rcx
+	shr ecx, 4		; Convert xAPIC register to x2APIC
+	add ecx, 0x800		; Add MSR base offset
+	rdmsr			; Read to EDX:EAX
+	shl rdx, 32		; Shift to upper 32 bits
+	or rax, rdx		; Combine into RAX
+	pop rcx
+	pop rdx
 	ret
 ; -----------------------------------------------------------------------------
 
 
 ; -----------------------------------------------------------------------------
-; os_apic_write -- Write to a register in the APIC
+; os_apic_write -- Write to a register in the APIC/x2APIC
 ;  IN:	ECX = Register to write
-;	EAX = Value to write
+;	RAX = Value to write
 ; OUT:	All registers preserved
 os_apic_write:
+	cmp byte [os_x2APIC], 1
+	je os_apic_write_x2
+
+os_apic_write_x:
 	push rcx
 	add rcx, [os_LocalAPICAddress]
 	mov [rcx], eax
 	pop rcx
+	ret
+
+os_apic_write_x2:
+	push rdx
+	push rcx
+	shr ecx, 4		; Convert xAPIC register to x2APIC
+	add ecx, 0x800		; Add MSR base offset
+	mov rdx, rax		; Copy RAX to RDX
+	shr rdx, 32		; Shift upper 32 bits to lower 32
+	wrmsr			; Write as EDX:EAX
+	pop rcx
+	pop rdx
 	ret
 ; -----------------------------------------------------------------------------
 
@@ -63,6 +95,7 @@ APIC_TMR	equ 0x180		; Trigger Mode Register (Starting Address)
 APIC_IRR	equ 0x200		; Interrupt Request Register (Starting Address)
 APIC_ESR	equ 0x280		; Error Status Register
 ; 0x290 - 0x2E0 are Reserved
+APIC_ICR	equ 0x300		; Interrupt Command Register - x2APIC
 APIC_ICRL	equ 0x300		; Interrupt Command Register (low 32 bits)
 APIC_ICRH	equ 0x310		; Interrupt Command Register (high 32 bits)
 APIC_LVT_TMR	equ 0x320		; LVT Timer Register

--- a/src/init/64.asm
+++ b/src/init/64.asm
@@ -52,6 +52,9 @@ init_64:
 	mov [os_pcie_count], ax
 	lodsw
 	mov [os_boot_arch], ax
+	mov esi, 0x000050E1		; x2APIC enabled
+	lodsb
+	mov [os_x2APIC], al
 	mov esi, 0x000050E2
 	lodsb
 	mov [os_boot_mode], al

--- a/src/interrupt.asm
+++ b/src/interrupt.asm
@@ -113,12 +113,27 @@ ap_wakeup:
 align 8
 ap_reset:
 	; Don't use 'os_apic_write' as we can't guarantee the state of the stack
+
 	mov eax, ap_clear		; Set RAX to the address of ap_clear
 	mov [rsp], rax			; Overwrite the return address on the CPU's stack
+
+	cmp byte [os_x2APIC], 1
+	je ap_reset_x2apic
+
+ap_reset_apic:
 	mov rdi, [os_LocalAPICAddress]	; Acknowledge the IPI
 	add rdi, 0xB0
 	xor eax, eax
 	stosd
+	jmp ap_reset_done
+
+ap_reset_x2apic:
+	mov ecx, 0x80B			; Acknowledge the IPI
+	xor eax, eax
+	xor edx, edx
+	wrmsr
+
+ap_reset_done:
 	iretq				; Return from the IPI. CPU will execute code at ap_clear
 ; -----------------------------------------------------------------------------
 

--- a/src/kernel.asm
+++ b/src/kernel.asm
@@ -46,12 +46,16 @@ start:
 start_payload:
 	cmp byte [os_payload], 0
 	je ap_clear			; If no payload was present then skip to ap_clear
-	mov rsi, [os_LocalAPICAddress]	; We can't use b_smp_get_id as no configured stack yet
+	mov ecx, APIC_TPR
 	xor eax, eax			; Clear Task Priority (bits 7:4) and Task Priority Sub-Class (bits 3:0)
-	mov dword [rsi+0x80], eax	; APIC Task Priority Register (TPR)
-	mov eax, dword [rsi+0x20]	; APIC ID in upper 8 bits
-	shr eax, 24			; Shift to the right and AL now holds the CPU's APIC ID
-	mov [os_BSP], al		; Keep a record of the BSP APIC ID
+	call os_apic_write
+	mov ecx, APIC_ID
+	call os_apic_read
+	cmp byte [os_x2APIC], 1		; Check for x2APIC
+	je start_payload_skip_shift	; If enabled skip the shr
+	shr rax, 24		; AL now holds the CPU's APIC ID (0 - 255)
+start_payload_skip_shift:
+	mov [os_BSP], eax		; Keep a record of the BSP APIC ID
 	mov ebx, eax			; Save the APIC ID
 	mov rdi, os_SMP			; Clear the entry in the work table
 	shl rax, 3			; Quick multiply by 8 to get to proper record
@@ -68,6 +72,10 @@ align 16
 ap_clear:				; All cores start here on first start-up and after an exception
 	cli				; Disable interrupts on this core
 
+	cmp byte [os_x2APIC], 1
+	je ap_clear_x2apic
+
+ap_clear_apic:
 	; Get local ID of the core
 	mov rsi, [os_LocalAPICAddress]	; We can't use b_smp_get_id as no configured stack yet
 	xor eax, eax			; Clear Task Priority (bits 7:4) and Task Priority Sub-Class (bits 3:0)
@@ -75,7 +83,18 @@ ap_clear:				; All cores start here on first start-up and after an exception
 	mov eax, dword [rsi+0x20]	; APIC ID in upper 8 bits
 	shr eax, 24			; Shift to the right and AL now holds the CPU's APIC ID
 	mov ebx, eax			; Save the APIC ID
+	jmp ap_clear_apic_done
 
+ap_clear_x2apic:
+	mov ecx, 0x808			; x2APIC TPR
+	xor eax, eax
+	xor edx, edx
+	wrmsr
+	mov ecx, 0x802			; x2APIC ID
+	rdmsr
+	mov ebx, eax			; Save the APIC ID
+
+ap_clear_apic_done:
 	; Clear the entry in the work table
 	mov rdi, os_SMP
 	shl rax, 3			; Quick multiply by 8 to get to proper record

--- a/src/syscalls/smp.asm
+++ b/src/syscalls/smp.asm
@@ -8,14 +8,17 @@
 
 ; -----------------------------------------------------------------------------
 ; b_smp_reset -- Resets a CPU Core
-;  IN:	AL = CPU #
+;  IN:	EAX = CPU #
 ; OUT:	Nothing. All registers preserved.
 ; Note:	This code resets an AP for set-up use only.
 b_smp_reset:
 	push rcx
 	push rax
-
 	cli
+
+	cmp byte [os_x2APIC], 1	; Check for x2APIC
+	je b_smp_reset_x2apic
+
 b_smp_reset_wait:
 	mov ecx, APIC_ICRL
 	call os_apic_read
@@ -29,8 +32,16 @@ b_smp_reset_wait:
 	xor eax, eax		; Clear EAX, namely bits 31:24
 	mov al, 0x81		; Execute interrupt 0x81
 	call os_apic_write	; Then write to the low bits
-	sti
+	jmp b_smp_reset_done
 
+b_smp_reset_x2apic:
+	mov ecx, APIC_ICR
+	shl rax, 32		; Shift APIC ID into upper 32 bits
+	mov al, 0x81		; Execute interrupt 0x81
+	call os_apic_write	; Then write to the low bits
+
+b_smp_reset_done:
+	sti
 	pop rax
 	pop rcx
 	ret
@@ -39,13 +50,16 @@ b_smp_reset_wait:
 
 ; -----------------------------------------------------------------------------
 ; b_smp_wakeup -- Wake up a CPU Core
-;  IN:	AL = CPU #
+;  IN:	EAX = CPU #
 ; OUT:	Nothing. All registers preserved.
 b_smp_wakeup:
 	push rcx
 	push rax
-
 	cli
+
+	cmp byte [os_x2APIC], 1	; Check for x2APIC
+	je b_smp_wakeup_x2apic
+
 b_smp_wakeup_wait:
 	mov ecx, APIC_ICRL
 	call os_apic_read
@@ -57,10 +71,18 @@ b_smp_wakeup_wait:
 	call os_apic_write	; Write to the high bits first
 	mov ecx, APIC_ICRL
 	xor eax, eax		; Clear EAX, namely bits 31:24
-	mov al, 0x80		; Execute interrupt 0x81
+	mov al, 0x80		; Execute interrupt 0x80
 	call os_apic_write	; Then write to the low bits
-	sti
+	jmp b_smp_wakeup_done
 
+b_smp_wakeup_x2apic:
+	mov ecx, APIC_ICR
+	shl rax, 32
+	mov al, 0x80		; Execute interrupt 0x80
+	call os_apic_write
+
+b_smp_wakeup_done:
+	sti
 	pop rax
 	pop rcx
 	ret
@@ -74,8 +96,11 @@ b_smp_wakeup_wait:
 b_smp_wakeup_all:
 	push rcx
 	push rax
-
 	cli
+
+	cmp byte [os_x2APIC], 1	; Check for x2APIC
+	je b_smp_wakeup_all_x2apic
+
 b_smp_wakeup_all_wait:
 	mov ecx, APIC_ICRL
 	call os_apic_read
@@ -87,8 +112,15 @@ b_smp_wakeup_all_wait:
 	mov ecx, APIC_ICRL
 	mov eax, 0x000C0080	; Execute interrupt 0x80 on All Excluding Self (0xC)
 	call os_apic_write	; Then write to the low bits
-	sti
+	jmp b_smp_wakeup_all_done
 
+b_smp_wakeup_all_x2apic:
+	mov ecx, APIC_ICR
+	mov eax, 0x000C0080	; Execute interrupt 0x80 on All Excluding Self (0xC)
+	call os_apic_write
+
+b_smp_wakeup_all_done:
+	sti
 	pop rax
 	pop rcx
 	ret
@@ -103,9 +135,14 @@ b_smp_get_id:
 	push rcx
 
 	mov ecx, APIC_ID
-	call os_apic_read	; Write to the high bits first
+	call os_apic_read
+
+	cmp byte [os_x2APIC], 1	; Check for x2APIC
+	je b_smp_get_id_done	; If enabled skip the shr
+
 	shr rax, 24		; AL now holds the CPU's APIC ID (0 - 255)
 
+b_smp_get_id_done:
 	pop rcx
 	ret
 ; -----------------------------------------------------------------------------

--- a/src/sysvar.asm
+++ b/src/sysvar.asm
@@ -97,6 +97,7 @@ os_AHCI_PA:		equ os_SystemVariables + 0x0108	; Each set bit is an active port
 os_NVMeTotalLBA:	equ os_SystemVariables + 0x010C
 os_apic_ver:		equ os_SystemVariables + 0x0110
 os_HPET_Frequency:	equ os_SystemVariables + 0x0114
+os_BSP:			equ os_SystemVariables + 0x0118
 os_xhci_int0_count:	equ os_SystemVariables + 0x011C	; Incremented on xHCI Interrupter 0
 
 
@@ -121,6 +122,7 @@ os_BusEnabled:		equ os_SystemVariables + 0x0303	; 1 if PCI is enabled, 2 if PCIe
 os_NetEnabled:		equ os_SystemVariables + 0x0304	; 1 if a supported network card was enabled
 os_payload:		equ os_SystemVariables + 0x0305
 os_boot_mode:		equ os_SystemVariables + 0x0306
+os_x2APIC:		equ os_SystemVariables + 0x0307
 os_NVMeIRQ:		equ os_SystemVariables + 0x030C
 os_NVMeMJR:		equ os_SystemVariables + 0x030D
 os_NVMeMNR:		equ os_SystemVariables + 0x030E
@@ -134,7 +136,6 @@ os_AHCI_IRQ:		equ os_SystemVariables + 0x0315
 os_ioapic_ver:		equ os_SystemVariables + 0x0316
 os_ioapic_mde:		equ os_SystemVariables + 0x0317
 key_control:		equ os_SystemVariables + 0x0318
-os_BSP:			equ os_SystemVariables + 0x0319
 os_HPET_IRQ:		equ os_SystemVariables + 0x031A
 os_net_icount:		equ os_SystemVariables + 0x031B
 


### PR DESCRIPTION
This pull request adds support for x2APIC (Extended xAPIC) in the kernel, allowing the system to use either the legacy xAPIC or the newer x2APIC mode for APIC register access and SMP (Symmetric Multiprocessing) operations. The changes introduce runtime detection and handling of x2APIC, update APIC read/write routines, and modify SMP-related syscalls to be compatible with both modes. New system variables are introduced to store x2APIC state and the BSP (Bootstrap Processor) ID.

**x2APIC Support and APIC Access:**

* Updated `os_apic_read` and `os_apic_write` in `apic.asm` to support both xAPIC (MMIO) and x2APIC (MSR) access methods, using the new `os_x2APIC` variable to select the mode at runtime.
* Added `APIC_ICR` definition for x2APIC and adjusted APIC register handling accordingly.

**System Variable Additions:**

* Introduced `os_x2APIC` and relocated `os_BSP` to more appropriate locations in `sysvar.asm` for tracking x2APIC state and the BSP ID. [[1]](diffhunk://#diff-cc3a0e25a8755cb8a9c7753db2348f5707203afdd141d283160646f59dfbfc19R100) [[2]](diffhunk://#diff-cc3a0e25a8755cb8a9c7753db2348f5707203afdd141d283160646f59dfbfc19R125) [[3]](diffhunk://#diff-cc3a0e25a8755cb8a9c7753db2348f5707203afdd141d283160646f59dfbfc19L137)

**SMP and APIC Initialization:**

* Modified SMP syscalls (`b_smp_reset`, `b_smp_wakeup`, `b_smp_wakeup_all`, `b_smp_get_id`) in `smp.asm` to use the correct APIC/x2APIC access method and register layout, including correct handling of APIC IDs and ICR register usage. [[1]](diffhunk://#diff-9bdf6e24f0ef0ed9dd438b5362e4301bb3c65ede1ab61574b201b09112c8867fL11-R21) [[2]](diffhunk://#diff-9bdf6e24f0ef0ed9dd438b5362e4301bb3c65ede1ab61574b201b09112c8867fL32-R44) [[3]](diffhunk://#diff-9bdf6e24f0ef0ed9dd438b5362e4301bb3c65ede1ab61574b201b09112c8867fL42-R62) [[4]](diffhunk://#diff-9bdf6e24f0ef0ed9dd438b5362e4301bb3c65ede1ab61574b201b09112c8867fL60-R85) [[5]](diffhunk://#diff-9bdf6e24f0ef0ed9dd438b5362e4301bb3c65ede1ab61574b201b09112c8867fL77-R103) [[6]](diffhunk://#diff-9bdf6e24f0ef0ed9dd438b5362e4301bb3c65ede1ab61574b201b09112c8867fL90-R123) [[7]](diffhunk://#diff-9bdf6e24f0ef0ed9dd438b5362e4301bb3c65ede1ab61574b201b09112c8867fL106-R145)

**Kernel and Interrupt Handling:**

* Updated kernel initialization and AP startup code in `kernel.asm` and `interrupt.asm` to use the new APIC/x2APIC routines, ensuring proper initialization and APIC ID retrieval regardless of mode. [[1]](diffhunk://#diff-0776db68c315e800fcd0e0d0d3bab7e7cca376cb86d0d0c515c68944e786df38L49-R58) [[2]](diffhunk://#diff-0776db68c315e800fcd0e0d0d3bab7e7cca376cb86d0d0c515c68944e786df38R75-R97) [[3]](diffhunk://#diff-a675b1c50a585b282c19d359766ba04e0f1407620e788a6593395a6b95029324R116-R136)

**Boot Parameter Handling:**

* Added logic in `init/64.asm` to detect and store x2APIC enablement during boot.